### PR TITLE
fixing go installer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,12 @@ RUN apt-get update && apt-get install -y \
 
 RUN export HOME=/root && curl -s -L https://raw.githubusercontent.com/moovweb/gvm/master/binscripts/gvm-installer | bash;
 
-RUN /bin/bash -c ". /root/.gvm/scripts/gvm && gvm install go1.1";
-RUN /bin/bash -c ". /root/.gvm/scripts/gvm && gvm install go1.2";
-RUN /bin/bash -c ". /root/.gvm/scripts/gvm && gvm install go1.3";
-RUN /bin/bash -c ". /root/.gvm/scripts/gvm && gvm install release";
-RUN /bin/bash -c ". /root/.gvm/scripts/gvm && gvm install tip";
+RUN /bin/bash -c ". /root/.gvm/scripts/gvm && gvm install go1.1 --prefer-binary";
+RUN /bin/bash -c ". /root/.gvm/scripts/gvm && gvm install go1.2 --prefer-binary";
+RUN /bin/bash -c ". /root/.gvm/scripts/gvm && gvm install go1.3 --prefer-binary";
+RUN /bin/bash -c ". /root/.gvm/scripts/gvm && gvm install go1.4 --prefer-binary";
+RUN /bin/bash -c ". /root/.gvm/scripts/gvm && (gvm install release --prefer-binary || true)";
+RUN /bin/bash -c ". /root/.gvm/scripts/gvm && (gvm install tip --prefer-binary || true)";
 
 env GVM_ROOT /root/.gvm
 env PATH $PATH:/root/.gvm/bin


### PR DESCRIPTION
- https://github.com/Shippable/pm/issues/2519
- the problem was with the `release` and `tip` versions of go
- the script does not fail now if the rlease and tip versions are not found